### PR TITLE
Feature/fix differentiable conformance

### DIFF
--- a/Animation/Sources/CollectionViewModel+DifferenceKit.swift
+++ b/Animation/Sources/CollectionViewModel+DifferenceKit.swift
@@ -30,10 +30,9 @@ extension CollectionViewSectionViewModel: ContentIdentifiable {
 
 /// This conformance allows for DifferenceKit to create StagedChangeSet which in turn enable to animate changes.
 /// If you find yourself unable to create a changeSet using StagedChangeSet(source:,target:) with you ViewModel
-/// you should check on the conditions which are that your CellViewModel conforms to Hashable and Differentiable
-/// and the same goes for your SupplementaryViewModel.
-/// Note that Never conformance to Hashable is handled by Swift and conformance to Differentiable is handled
-/// by this pod.
+/// you should check on the conditions which are that your CellViewModel conforms to Differentiable
+/// and SupplementaryViewModel conforms to ContentEquatable.
+/// Note that Never conformance to Differentiable is handled by this pod.
 extension CollectionViewSectionViewModel: DifferentiableSection where
     CellViewModel: Differentiable,
     SupplementaryViewModel: ContentEquatable {

--- a/Animation/Sources/CollectionViewModel+DifferenceKit.swift
+++ b/Animation/Sources/CollectionViewModel+DifferenceKit.swift
@@ -1,12 +1,25 @@
 import CollectionModelCore
 import DifferenceKit
 
+extension Dictionary: ContentEquatable where Value: ContentEquatable {
+    public func isContentEqual(to source: [Key: Value]) -> Bool {
+        guard keys == source.keys else { return false }
+        for (key, value) in self {
+            guard let sourceValue = source[key] else { return false }
+            if !value.isContentEqual(to: sourceValue) { return false }
+        }
+        return true
+    }
+}
 
 extension CollectionViewSectionViewModel: ContentEquatable where
     CellViewModel: Hashable & Differentiable,
     SupplementaryViewModel: Hashable & Differentiable {
     public func isContentEqual(to source: Self) -> Bool {
         return id.isContentEqual(to: source.id)
+            && supplementaryViewModels.isContentEqual(to: source.supplementaryViewModels)
+            && header.isContentEqual(to: source.header)
+            && footer.isContentEqual(to: source.footer)
     }
 }
 

--- a/Animation/Sources/CollectionViewModel+DifferenceKit.swift
+++ b/Animation/Sources/CollectionViewModel+DifferenceKit.swift
@@ -13,8 +13,7 @@ extension Dictionary: ContentEquatable where Value: ContentEquatable {
 }
 
 extension CollectionViewSectionViewModel: ContentEquatable where
-    CellViewModel: Hashable & Differentiable,
-    SupplementaryViewModel: Hashable & Differentiable {
+    SupplementaryViewModel: ContentEquatable {
     public func isContentEqual(to source: Self) -> Bool {
         return id.isContentEqual(to: source.id)
             && supplementaryViewModels.isContentEqual(to: source.supplementaryViewModels)
@@ -23,9 +22,7 @@ extension CollectionViewSectionViewModel: ContentEquatable where
     }
 }
 
-extension CollectionViewSectionViewModel: ContentIdentifiable where
-    CellViewModel: Hashable & Differentiable,
-    SupplementaryViewModel: Hashable & Differentiable {
+extension CollectionViewSectionViewModel: ContentIdentifiable {
     public var differenceIdentifier: String {
         return id
     }
@@ -38,8 +35,8 @@ extension CollectionViewSectionViewModel: ContentIdentifiable where
 /// Note that Never conformance to Hashable is handled by Swift and conformance to Differentiable is handled
 /// by this pod.
 extension CollectionViewSectionViewModel: DifferentiableSection where
-    CellViewModel: Hashable & Differentiable,
-    SupplementaryViewModel: Hashable & Differentiable {
+    CellViewModel: Differentiable,
+    SupplementaryViewModel: ContentEquatable {
     public init<C>(source: CollectionViewSectionViewModel,
                    elements: C) where C: Swift.Collection, C.Element == CellViewModel {
         self.init(

--- a/Animation/Sources/TableViewModel+DifferenceKit.swift
+++ b/Animation/Sources/TableViewModel+DifferenceKit.swift
@@ -10,8 +10,7 @@ import CollectionModelCore
 import DifferenceKit
 
 extension TableViewSectionViewModel: ContentEquatable where
-    CellViewModel: Hashable & Differentiable,
-    HeaderFooterViewModel: Hashable & Differentiable {
+    HeaderFooterViewModel: ContentEquatable {
     public func isContentEqual(to source: TableViewSectionViewModel<HeaderFooterViewModel, CellViewModel>) -> Bool {
         return id.isContentEqual(to: source.id)
             && header.isContentEqual(to: source.header)
@@ -19,9 +18,7 @@ extension TableViewSectionViewModel: ContentEquatable where
     }
 }
 
-extension TableViewSectionViewModel: ContentIdentifiable where
-    CellViewModel: Hashable & Differentiable,
-    HeaderFooterViewModel: Hashable & Differentiable {
+extension TableViewSectionViewModel: ContentIdentifiable {
     public var differenceIdentifier: String {
         return id
     }
@@ -34,8 +31,8 @@ extension TableViewSectionViewModel: ContentIdentifiable where
 /// Note that Never conformance to Hashable is handled by Swift and conformance to Differentiable is handled
 /// by this pod.
 extension TableViewSectionViewModel: DifferentiableSection where
-    CellViewModel: Hashable & Differentiable,
-    HeaderFooterViewModel: Hashable & Differentiable {
+    CellViewModel: Differentiable,
+    HeaderFooterViewModel: ContentEquatable {
 
     public init<C>(source: TableViewSectionViewModel,
                    elements: C) where C: Swift.Collection, C.Element == CellViewModel {

--- a/Animation/Sources/TableViewModel+DifferenceKit.swift
+++ b/Animation/Sources/TableViewModel+DifferenceKit.swift
@@ -26,10 +26,9 @@ extension TableViewSectionViewModel: ContentIdentifiable {
 
 /// This conformance allows for DifferenceKit to create StagedChangeSet which in turn enable to animate changes.
 /// If you find yourself unable to create a changeSet using StagedChangeSet(source:,target:) with you ViewModel
-/// you should check on the conditions which are that your CellViewModel conforms to Hashable and Differentiable
-/// and the same goes for your HeaderFooterViewModel.
-/// Note that Never conformance to Hashable is handled by Swift and conformance to Differentiable is handled
-/// by this pod.
+/// you should check on the conditions which are that your CellViewModel conforms to Differentiable
+/// and HeaderFooterViewModel conforms to ContentEquatable.
+/// Note that Never conformance to Differentiable is handled by this pod.
 extension TableViewSectionViewModel: DifferentiableSection where
     CellViewModel: Differentiable,
     HeaderFooterViewModel: ContentEquatable {

--- a/Animation/Sources/TableViewModel+DifferenceKit.swift
+++ b/Animation/Sources/TableViewModel+DifferenceKit.swift
@@ -14,6 +14,8 @@ extension TableViewSectionViewModel: ContentEquatable where
     HeaderFooterViewModel: Hashable & Differentiable {
     public func isContentEqual(to source: TableViewSectionViewModel<HeaderFooterViewModel, CellViewModel>) -> Bool {
         return id.isContentEqual(to: source.id)
+            && header.isContentEqual(to: source.header)
+            && footer.isContentEqual(to: source.footer)
     }
 }
 


### PR DESCRIPTION
For the moment, headers, footers (and supplementaryViewModels) are not tested when a section view model is asked if its content is similar to another.

This patch fixes the bug.